### PR TITLE
refactor(lib): Get rid of runtime, async/await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,3 @@
 {
-  "stage": 0,
-  "optional": [
-    "runtime"
-  ]
+  "stage": 0
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^5.8.29",
     "chalk": "^1.1.1",
     "chrono-node": "^1.0.8",
     "dateformat": "^1.0.11",

--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,22 @@
 import getReviews from './util/getReviews';
+import promiseProps from 'promise-props';
 import { transform } from './util/format';
 
-export default async function fido(config, page = 1, fromDate = null) {
-  const output = {};
+export default function fido(config, page = 1, fromDate = null) {
+  const allPromises = config.reduce((all, cfg) => {
+    all[cfg.podcastId] = getReviews(cfg.countries, page, cfg.podcastId)
+      .then(review => {
+        return {
+          name: cfg.name,
+          fromDate,
+          id: cfg.podcastId,
+          data: review,
+          reviews: transform(review, fromDate),
+        };
+      });
 
-  for (const cfg of config) {
-    output[cfg.podcastId] = {
-      name: cfg.name,
-      fromDate,
-      id: cfg.podcastId,
-    };
+    return all;
+  }, {});
 
-    try {
-      output[cfg.podcastId].data = await getReviews(cfg.countries, page, cfg.podcastId);
-      output[cfg.podcastId].reviews = transform(output[cfg.podcastId].data, fromDate);
-    } catch (e) {
-      output[cfg.podcastId].data = null;
-      output[cfg.podcastId].reviews = null;
-    }
-  }
-
-  return output;
+  return promiseProps(allPromises);
 }


### PR DESCRIPTION
Relying on async/await generators and the babel-runtime just for async/await at one single space
isn't the most important part. This reduces the code by quite a lot and makes it way simpler.

It’s just an idea, so…. :)