### PR TITLE
Updates chalk to version 2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "Base64": "^0.3.0",
-    "chalk": "^1.1.1",
+    "chalk": "^2.0.0",
     "chrono-node": "^1.0.8",
     "dateformat": "^1.0.11",
     "isomorphic-fetch": "^2.2.0",
@@ -36,7 +36,8 @@
     "user-home": "^2.0.0",
     "xml2js": "^0.4.16",
     "yam": "^0.0.19",
-    "yargs": "^4.1.0"
+    "yargs": "^4.1.0",
+    "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
     "ava": "^0.15.1",

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+import stripAnsi from 'strip-ansi'
 import test from 'ava';
 import 'babel-register';
 import { getResult, getXMLresult } from '../src/util/parseXML';
@@ -5,7 +6,6 @@ import { format, transform } from '../src/util/format';
 import getReviews from '../src/util/getReviews';
 import { readFileSync } from 'fs';
 import nock from 'nock';
-import { stripColor } from 'chalk';
 
 test('parseXML/getResult', t => {
   t.plan(4);
@@ -51,7 +51,7 @@ test('getReviews', t => {
 
 test('format', t => {
   const data = JSON.parse(readFileSync('./fixture/format.json', { encoding: 'utf8' }));
-  const output = stripColor(format(transform(data)));
+  const output = stripAnsi(format(transform(data)));
   const fixture = readFileSync('./fixture/format.txt', { encoding: 'utf8' });
 
   t.deepEqual(output, fixture);


### PR DESCRIPTION
A review of the code indicates that no other parts are affected by the breaking changes in the library update.